### PR TITLE
Create wrap files for nlohmann_json-3.4.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,13 @@
+project('nlohmann_json', 'cpp', version : '3.4.0', license : 'MIT')
+
+nlohmann_json_dep = declare_dependency(
+    include_directories: include_directories('include')
+)
+
+install_subdir('include', install_dir: '.')
+
+pkgc = import('pkgconfig')
+pkgc.generate(name: 'nlohmann_json',
+    version: meson.project_version(),
+    description: 'JSON for Modern C++'
+)

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,7 @@
+[wrap-file]
+directory = nlohmann_json-3.4.0
+lead_directory_missing = true
+
+source_url = https://github.com/nlohmann/json/releases/download/v3.4.0/include.zip
+source_filename = nlohmann_json-3.4.0.zip
+source_hash = bfec46fc0cee01c509cf064d2254517e7fa80d1e7647fea37cf81d97c5682bdc


### PR DESCRIPTION
In a few words, this PR does the following.
- Update the wrap to the [latest release] of nlohmann_json.
- Use the released [include.zip] instead of [sources.zip], which drastically reduces the size of the downloaded content (110 MB -> 135 kB).

I am very new to Meson and its wrap system, please do not hesitate to tell if the PR can be improved.
I ran simple tests on the following wrap file and it seemed to work.

```
[wrap-file]
directory = nlohmann_json-3.4.0
lead_directory_missing = true

source_url = https://github.com/nlohmann/json/releases/download/v3.4.0/include.zip
source_filename = nlohmann-json-3.4.0.zip
source_hash = bfec46fc0cee01c509cf064d2254517e7fa80d1e7647fea37cf81d97c5682bdc

patch_url = https://github.com/mpoquet/nlohmann_json/archive/3.4.0.zip
patch_filename = nlohmann-json-3.4.0-wrap.zip
patch_hash = dbb3afe9a93e890dafc3432954b33a368c947b15005c52533b566f3b049cb92b

```

PS: I tried to avoid Meson code duplication by proposing nlohmann to release a lightweight version of the sources but he was not interested (to simplify his release process, and to keep packaging issues out of the main repo).

[latest release]: https://github.com/nlohmann/json/releases/tag/v3.4.0
[include.zip]: https://github.com/nlohmann/json/releases/download/v3.4.0/include.zip
[sources.zip]: https://github.com/nlohmann/json/archive/v3.4.0.zip